### PR TITLE
lua/ts: Adjust highlight of fields and constructors

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -2118,6 +2118,8 @@ highlight! link luaFunc Green
 highlight! link luaFunction Aqua
 highlight! link luaTable Fg
 highlight! link luaIn RedItalic
+highlight! link luaTSField Fg
+highlight! link luaTSConstructor Fg
 " }}}
 " vim-lua: https://github.com/tbastos/vim-lua {{{
 highlight! link luaFuncCall Green


### PR DESCRIPTION
### Description

Fixes the exuberance of green-aqua shade in Lua tables when Treesitter highlighting is enabled.
Addresses my concern with Lua tables described in https://github.com/sainnhe/everforest/issues/74#issuecomment-1214135710

### Screenshots

Before

<img width="986" alt="lua_ts_everforest" src="https://user-images.githubusercontent.com/3299086/184479631-f84f2ac3-1035-4cc7-9874-41aa963d792b.png">

After

![image](https://user-images.githubusercontent.com/3299086/184486536-e2d39b35-dd5d-41a4-b30c-23da17e97caf.png)