### PR TITLE
yaml/ts: Adjust highlight of keys and string values

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -2574,8 +2574,10 @@ highlight! link jsonQuote Grey
 highlight! link jsonBraces Fg
 " syn_end }}}
 " syn_begin: yaml {{{
-highlight! link yamlKey Orange
+highlight! link yamlKey Green
 highlight! link yamlConstant Purple
+highlight! link yamlTSField Green
+highlight! link yamlTSString Fg
 " syn_end }}}
 " syn_begin: toml {{{
 call everforest#highlight('tomlTable', s:palette.purple, s:palette.none, 'bold')


### PR DESCRIPTION
### Description

Fixes the exuberance of green-aqua shade in YAML documents when Treesitter highlighting is enabled.
Addresses my concern with YAML keys and values described in https://github.com/sainnhe/everforest/issues/74.

I picked `Orange` because that's what `yamlKey` is currently set to, but I see this color was copied from gruvbox-material, so let me know if you want me to change it to something else :) 

Fixes #74
(my concerns are only for YAML and [Lua](https://github.com/sainnhe/everforest/issues/75), I don't think any other action is needed for other languages)

### Screenshots

Before

<img width="1031" alt="yaml_ts_everforest" src="https://user-images.githubusercontent.com/3299086/184479371-eaa1787b-08f3-45eb-9b15-8e053b23c5da.png">

After

<img width="1010" alt="yaml_ts_fix" src="https://user-images.githubusercontent.com/3299086/184492589-5a74a558-5519-472a-bc92-dd33f2ff4d49.png">