### PR TITLE
json/ts: Switch to Green as dominant color

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -2571,9 +2571,11 @@ highlight! link cmakeKWvariable_watch Aqua
 highlight! link cmakeKWwrite_file Aqua
 " syn_end }}}
 " syn_begin: json {{{
-highlight! link jsonKeyword Orange
+highlight! link jsonKeyword Green
+highlight! link jsonString Fg
 highlight! link jsonQuote Grey
-highlight! link jsonBraces Fg
+highlight! link jsonTSLabel jsonKeyword
+highlight! link jsonTSString jsonString
 " syn_end }}}
 " syn_begin: yaml {{{
 highlight! link yamlKey Green


### PR DESCRIPTION
### Description

The current highlighting for the `json` filetype was borrowed from Gruvbox Material, and has Orange as dominant color.
This doesn't fit very well with Everforest's general Green direction, so I propose we tweak the colors to make them more subtle, with a dominant of green/beige.

Because a large portion of the symbols in a JSON document are _strings_, I highlighted these using the Foreground color to avoid overwhelming the reader with too much of a single warm color.

### Screenshots

Before

![image](https://user-images.githubusercontent.com/3299086/184536346-0861fb4b-0803-4223-a649-09266e4e7a18.png)

After

![image](https://user-images.githubusercontent.com/3299086/184536303-306fd5a5-f54b-43b3-8034-1f5b9d74dd6e.png)
