### PR TITLE
toml/ts: Switch to Green as dominant color

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -2582,10 +2582,14 @@ highlight! link yamlTSField Green
 highlight! link yamlTSString Fg
 " syn_end }}}
 " syn_begin: toml {{{
-call everforest#highlight('tomlTable', s:palette.purple, s:palette.none, 'bold')
-highlight! link tomlKey Orange
+call everforest#highlight('tomlTable', s:palette.orange, s:palette.none, 'bold')
+highlight! link tomlKey Green
+highlight! link tomlString Fg
+highlight! link tomlDate Special
 highlight! link tomlBoolean Aqua
 highlight! link tomlTableArray tomlTable
+highlight! link tomlTSProperty tomlKey
+highlight! link tomlTSString tomlString
 " syn_end }}}
 " syn_begin: gitcommit {{{
 highlight! link gitcommitSummary Red


### PR DESCRIPTION
### Description

Adjusts syntax highlight groups for the `toml` filetype to have Green as the dominant color instead of Orange.

Because a large portion of the symbols in a TOML document are _strings_, I highlighted these using the Foreground color to avoid overwhelming the reader with too much of a single warm color.

### Screenshots

Before

![image](https://user-images.githubusercontent.com/3299086/184538145-1aa19285-1233-4ec5-bd37-79e8143e4f41.png)

After

![image](https://user-images.githubusercontent.com/3299086/184538113-cc1a4b4f-806e-4526-8abe-e0a43db9a068.png)