### PR TITLE
yaml: Ensure consistent highlighting across syntaxes

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -2578,10 +2578,15 @@ highlight! link jsonTSLabel jsonKeyword
 highlight! link jsonTSString jsonString
 " syn_end }}}
 " syn_begin: yaml {{{
-highlight! link yamlKey Green
-highlight! link yamlConstant Purple
-highlight! link yamlTSField Green
-highlight! link yamlTSString Fg
+highlight! link yamlBlockMappingKey Green
+highlight! link yamlString Fg
+highlight! link yamlConstant OrangeItalic
+highlight! link yamlKeyValueDelimiter Grey
+highlight! link yamlTSField yamlBlockMappingKey
+highlight! link yamlTSString yamlString
+highlight! link yamlTSBoolean yamlConstant
+highlight! link yamlTSConstBuiltin yamlConstant
+highlight! link yamlKey yamlBlockMappingKey  " stephpy/vim-yaml
 " syn_end }}}
 " syn_begin: toml {{{
 call everforest#highlight('tomlTable', s:palette.orange, s:palette.none, 'bold')


### PR DESCRIPTION
### Description

Tackles a few more YAML highlight groups that were not covered in #76.

Depending on the YAML syntax enabled by the user, highlight groups may have different names. For example:

- Keys are `yamlBlockMappingKey` in Vim's core syntax, but `yamlKey` in [stephpy/vim-yaml](https://github.com/stephpy/vim-yaml) (a custom YAML syntax that was popular on older Vim versions)
- Treesitter doesn't make any distinction between a String and a Scalar, but the core Vim syntax does.
- `yamlConstant` includes both booleans and null values in core Vim syntax, but in Treesitter syntax they are distinct

This PR provides consistent highlighting regardless of the syntax method:
- Keys are Green
- String values are Fg
- Built-in constants (booleans, null) are orange italic to differentiate from numbers, which are purple

My previous PR #76 didn't cover `yamlBlockMappingKey` and `yamlString` so YAML documents were highlighted differently in Vim's core syntax (keys were mapped to Identifier, which is Blue).

### Screenshots

With Vim's built-in syntax file (no change to other syntaxes since #76)

![before](https://user-images.githubusercontent.com/3299086/184845878-4ac1a95b-e3d0-4882-baa4-77fc712456e7.png)

![after](https://user-images.githubusercontent.com/3299086/184844475-1d27199e-32f8-4ba5-bd37-bde46dcd3b97.png)