### PR TITLE
go: Update groups based on current Vim built-in syntax

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -2182,18 +2182,26 @@ highlight! link scalaKeywordModifier Orange
 " }}}
 " syn_end }}}
 " syn_begin: go {{{
-" builtin: https://github.com/google/vim-ft-go {{{
-highlight! link goDirective PurpleItalic
-highlight! link goConstants Aqua
+" builtin: https://github.com/fatih/vim-go {{{
+highlight! link goPackage Define
+highlight! link goImport Include
+highlight! link goVar OrangeItalic
+highlight! link goConst goVar
+highlight! link goType Yellow
+highlight! link goSignedInts goType
+highlight! link goUnsignedInts goType
+highlight! link goFloats goType
+highlight! link goComplexes goType
+highlight! link goVarDefs Aqua
 highlight! link goDeclType OrangeItalic
-" }}}
-" polyglot: {{{
-highlight! link goPackage PurpleItalic
-highlight! link goImport PurpleItalic
-highlight! link goVarArgs Blue
-highlight! link goBuiltins Green
+highlight! link goFunctionCall Function
 highlight! link goPredefinedIdentifiers Aqua
-highlight! link goVar Orange
+highlight! link goBuiltins Function
+highlight! link goVarArgs Grey
+highlight! link goTSInclude Purple
+highlight! link goTSNamespace Fg
+highlight! link goTSProperty Identifier
+highlight! link goTSConstBuiltin AquaItalic
 " }}}
 " syn_end }}}
 " syn_begin: rust {{{


### PR DESCRIPTION
### Description

Since [v8.2.3117](https://github.com/vim/vim/commit/90df4b9d423485f7db16e3a65cab4f14edc815ae), Vim ships with the syntax file from fatih/vim-go, which has richer, more granular syntax highlight groups.

Because Polyglot was using this exact syntax file, the polyglot-specific section can now be merged with the regular Go syntax.

Go is my main programming language and I tried to make sensible choices in the additional highlight groups provided by the current Vim syntax (with corresponding Treesitter groups):
- built-in function calls -> same as normal function calls, but _italic_ (if enabled)
- built-in types -> same as custom types, but _italic_ (if enabled)
- namespaces (Treesitter only) -> Fg instead of TSNamespace (YellowItalic) to avoid a dominance of yellow on screen. We refer to things by their explicit package name in Go (e.g. `sync.Mutex`, `bytes.Buffer`, ...), and the type already defaults to Yellow.

### Screenshots

Before (Treesitter / Vim syntax)

![go-ts](https://user-images.githubusercontent.com/3299086/184921553-90f44072-5493-4219-9f63-2ac8eefcae27.png)
![go-vim](https://user-images.githubusercontent.com/3299086/184925853-7db9d4d8-ad35-4346-8fc9-55d989e9c1b1.png)

After (Treesitter / Vim syntax)

https://github.com/sainnhe/everforest/pull/81#issuecomment-1216869326

<details>
<summary>
initial screenshots (old)
</summary>

![go-ts](https://user-images.githubusercontent.com/3299086/184872687-887bdb37-35fe-42d3-bcb8-952debc74277.png)
![go-vim](https://user-images.githubusercontent.com/3299086/184872678-fe47e6dd-4e9f-4c4c-b99d-a38bf8acf67f.png)

</details>