### PR TITLE
js: Highlight template literals like strings

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -1645,6 +1645,7 @@ highlight! link javaScriptMember Aqua
 " }}}
 " vim-javascript: https://github.com/pangloss/vim-javascript {{{
 highlight! link jsString Aqua
+highlight! link jsTemplateString jsString
 highlight! link jsThis Purple
 highlight! link jsUndefined Aqua
 highlight! link jsNull Aqua


### PR DESCRIPTION
### Description

Fixes #83

Pinging @xmready for feedback.

### Screenshots

Before

<img width="525" alt="js-tmplstr" src="https://user-images.githubusercontent.com/3299086/185674994-63467c97-d33f-447a-9e3a-9c4fd81dc629.png">

After

<img width="537" alt="js-tmplstr" src="https://user-images.githubusercontent.com/3299086/185674653-5d67bbd0-c5ed-4bfd-9214-87e82f1fb8df.png">