### PR TITLE
fix(yaml/json): special highlight for escape chars

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -2576,6 +2576,7 @@ highlight! link jsonString Fg
 highlight! link jsonQuote Grey
 highlight! link jsonTSLabel jsonKeyword
 highlight! link jsonTSString jsonString
+highlight! link jsonTSStringEscape SpecialChar
 " syn_end }}}
 " syn_begin: yaml {{{
 highlight! link yamlBlockMappingKey Green
@@ -2584,6 +2585,7 @@ highlight! link yamlConstant OrangeItalic
 highlight! link yamlKeyValueDelimiter Grey
 highlight! link yamlTSField yamlBlockMappingKey
 highlight! link yamlTSString yamlString
+highlight! link yamlTSStringEscape SpecialChar
 highlight! link yamlTSBoolean yamlConstant
 highlight! link yamlTSConstBuiltin yamlConstant
 highlight! link yamlKey yamlBlockMappingKey  " stephpy/vim-yaml


### PR DESCRIPTION
### Description

In #76 and #77, highlights for the JSON and YAML file types were updated to move the green tones towards the left side (keys) to avoid a dominance of green across the screen, since JSON and YAML are typically mainly composed of strings.

I noticed that a subtle difference remains between the Vim and Treesitter highlights: escape characters — such as `\n`, `\t`, etc. — are highlighted as Yellow (_SpecialChar_) with Vim highlights, but as Green (_TSStringEscape_) with Treesitter highlights. This is expected because, [by design](https://github.com/sainnhe/gruvbox-material/issues/119), strings default to Green with Vim highlights, and Aqua with Treesitter highlights. However, strings are Foreground in both YAML and JSON documents, so suggest to use a color coding which differs from fields to make the semantics clearer.

I picked _SpecialChar_ because Vim's built-in syntaxes use this group by default, but if someone has a preference for a more contrasted tone (Blue, Aqua, Orange, Red) I'm also fine switching to that.

JSON Vim (_SpecialChar -> Yellow_)
<img width="572" alt="json-vim" src="https://user-images.githubusercontent.com/3299086/185799856-245b4e1f-aa65-404c-ba9e-5ad9d47a7238.png">

JSON Treesitter (_TSStringEscape -> Green_)
<img width="657" alt="json-ts" src="https://user-images.githubusercontent.com/3299086/185799853-9aa23e9c-777d-495c-adb3-7143ee5ba30b.png">

YAML Vim (_SpecialChar -> Yellow_)
<img width="729" alt="yaml-vim" src="https://user-images.githubusercontent.com/3299086/185799860-cb5a0d03-14e4-4956-b992-2bc6b97eb64f.png">

YAML Treesitter (_TSStringEscape -> Green_)
<img width="730" alt="yaml-ts" src="https://user-images.githubusercontent.com/3299086/185799858-fd81b7d4-2781-4c82-9221-08381eafdc22.png">

### Screenshots

Same as above, just with escape characters linked to Yellow in Treesitter hightlights, like with Vim highlights.