### PR TITLE
feat(git): highlight commit summary in green

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -10,7 +10,7 @@
 let s:configuration = everforest#get_configuration()
 let s:palette = everforest#get_palette(s:configuration.background, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = 'Sun Aug 21 09:09:11 UTC 2022'
+let s:last_modified = 'Mon Aug 22 15:25:18 UTC 2022'
 let g:everforest_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'everforest' && s:configuration.better_performance)
@@ -2601,7 +2601,7 @@ highlight! link tomlTSProperty tomlKey
 highlight! link tomlTSString tomlString
 " syn_end }}}
 " syn_begin: gitcommit {{{
-highlight! link gitcommitSummary Red
+highlight! link gitcommitSummary Green
 highlight! link gitcommitUntracked Grey
 highlight! link gitcommitDiscarded Grey
 highlight! link gitcommitSelected Grey


### PR DESCRIPTION
### Description

Git commit summaries are currently Red, which appears to have been directly inherited from [Gruvbox-Material](https://github.com/sainnhe/gruvbox-material/blob/master/colors/gruvbox-material.vim#L2677).

While this color might work well with the "retro groove" feeling of Gruvbox, it feels a bit out of place in the "green, calm" Everforest theme:
- Everforest usually uses red for short keywords (_func_, conditionals, etc.)
- Long sentences in red tend to look like errors

I suggest we change this to the dominant color of the scheme: Green.

### Screenshots

Before

<img width="1122" alt="before: red" src="https://user-images.githubusercontent.com/3299086/185956345-5efcc708-5178-45f9-93f7-d7522e267bc9.png">

After

<img width="1122" alt="after: green" src="https://user-images.githubusercontent.com/3299086/185956367-1563b097-3493-403d-8729-f812cd80e82b.png">