### PR TITLE
fix(lspsaga): Suppress undercurl in text and borders

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -10,7 +10,7 @@
 let s:configuration = everforest#get_configuration()
 let s:palette = everforest#get_palette(s:configuration.background, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = 'Thu Aug 25 10:46:22 UTC 2022'
+let s:last_modified = 'Fri Aug 26 09:21:03 UTC 2022'
 let g:everforest_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'everforest' && s:configuration.better_performance)
@@ -1034,8 +1034,16 @@ call everforest#highlight('LspFloatWinBorder', s:palette.bg0, s:palette.bg0)
 call everforest#highlight('LspSagaDiagnosticHeader', s:palette.orange, s:palette.none, 'bold')
 call everforest#highlight('LspSagaCodeActionTitle', s:palette.purple, s:palette.none, 'bold')
 call everforest#highlight('DefinitionPreviewTitle', s:palette.blue, s:palette.none, 'bold')
+highlight! link LspSagaDiagnosticError Red
+highlight! link LspSagaDiagnosticWarn Yellow
+highlight! link LspSagaDiagnosticInfo Blue
+highlight! link LspSagaDiagnosticHint Green
+highlight! link LspSagaErrorTrunCateLine LspSagaDiagnosticError
+highlight! link LspSagaWarnTrunCateLine LspSagaDiagnosticWarn
+highlight! link LspSagaInfoTrunCateLine LspSagaDiagnosticInfo
+highlight! link LspSagaHintTrunCateLine LspSagaDiagnosticHint
+highlight! link LspSagaDiagnosticSource Orange
 highlight! link LspSagaDiagnosticBorder Orange
-highlight! link LspSagaDiagnosticTruncateLine Orange
 highlight! link LspSagaRenameBorder Purple
 highlight! link LspSagaRenamePromptPrefix Blue
 highlight! link LspSagaCodeActionBorder Purple


### PR DESCRIPTION
### Description

Fixes #87

Re-link LspSaga's highlight groups that [currently link to undercurl groups](https://github.com/glepnir/lspsaga.nvim/blob/0797b968325ee4dc8dc68e124a8d9a18e6a81888/plugin/lspsaga.lua#L41-L48) to core colors to avoid undercurl on popup text and borders, as seen in #87.

### Screenshots

Before

<img width="546" alt="lspsaga" src="https://user-images.githubusercontent.com/3299086/186834929-d7a5971e-7e97-4a52-8e0f-193cc6e0ce14.png">
<img width="457" alt="err" src="https://user-images.githubusercontent.com/3299086/186838789-b124141c-90ea-4ba4-897e-58028bfb28f1.png">

After

<img width="446" alt="err-fixed" src="https://user-images.githubusercontent.com/3299086/186870756-6fc9158a-3eaa-4f77-96aa-2ebdbb899be3.png">
<img width="540" alt="hint-fixed" src="https://user-images.githubusercontent.com/3299086/186870767-888d72e8-b4a1-4ba9-a5a1-4c1a29bfd4be.png">