### PR TITLE
feat(js): Treesitter hl for includes and constructors

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -10,7 +10,7 @@
 let s:configuration = everforest#get_configuration()
 let s:palette = everforest#get_palette(s:configuration.background, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = 'Fri Aug 26 09:21:03 UTC 2022'
+let s:last_modified = 'Mon Aug 29 17:59:32 UTC 2022'
 let g:everforest_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'everforest' && s:configuration.better_performance)
@@ -1729,6 +1729,10 @@ highlight! link jsModuleKeyword Yellow
 highlight! link jsTemplateExpression Yellow
 highlight! link jsTemplateBraces Yellow
 highlight! link jsClassMethodType Orange
+" }}}
+" nvim-treesitter/nvim-treesitter {{{
+highlight! link javascriptTSInclude Purple
+highlight! link javascriptTSConstructor Yellow
 " }}}
 " yajs: https://github.com/othree/yajs.vim {{{
 highlight! link javascriptEndColons Fg


### PR DESCRIPTION
### Description

In https://github.com/sainnhe/everforest/pull/82, Javascript syntax highlight groups were optimized for "classic" Vim.

This PR suggests two minor additional optimisations specifically for Treesitter highlighting:

- `include` are purple to differentiate them from other keywords, which are all red
- `constructor` are yellow to differentiate them from functions, which are green

### Screenshots

Before

<img width="1085" alt="before" src="https://user-images.githubusercontent.com/3299086/187268008-bc6d2783-5a98-4de8-91f6-bda1b91c58b4.png">

After

<img width="1085" alt="after" src="https://user-images.githubusercontent.com/3299086/187268046-bad38594-bc24-4d6f-bc60-3adc5bd4a406.png">