### PR TITLE
make status line more visible

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -150,9 +150,9 @@ if s:configuration.transparent_background == 2
   call everforest#highlight('TabLineFill', s:palette.grey1, s:palette.none)
   call everforest#highlight('TabLineSel', s:palette.bg0, s:palette.statusline1)
 else
-  call everforest#highlight('StatusLine', s:palette.grey1, s:palette.bg1)
+  call everforest#highlight('StatusLine', s:palette.grey1, s:palette.bg2)
   call everforest#highlight('StatusLineTerm', s:palette.grey1, s:palette.bg1)
-  call everforest#highlight('StatusLineNC', s:palette.grey1, s:palette.bg0)
+  call everforest#highlight('StatusLineNC', s:palette.grey1, s:palette.bg1)
   call everforest#highlight('StatusLineTermNC', s:palette.grey1, s:palette.bg0)
   call everforest#highlight('TabLine', s:palette.grey2, s:palette.bg3)
   call everforest#highlight('TabLineFill', s:palette.grey1, s:palette.bg1)


### PR DESCRIPTION
### Description

I found the status bar to be too invisible in the default theme, so I bumped up the contrast one level for both the active and inactive status bar backgrounds.

I've been using this for several months and find it a big improvement - without it I frequently don't notice that I'm in a split.

### Screenshots

#### before

note that there is no visible background to the inactive status bar on top

<img width="1289" alt="Screen Shot 2022-10-25 at 2 32 55 PM" src="https://user-images.githubusercontent.com/7150/197854302-cdc6c554-df84-4caa-a990-b33c45aeca66.png">

#### after
<img width="1289" alt="Screen Shot 2022-10-25 at 2 33 22 PM" src="https://user-images.githubusercontent.com/7150/197854285-44339fc9-f428-40df-b98c-ccfa398eb49f.png">

This is an aesthetic change, so I'll understand and close the PR if you don't like it, but it's one I make on my local installations of your excellent theme.