### PR TITLE
fix(ui): remove "^^^" from transparent StatusLine in current window

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -158,7 +158,7 @@ endif
 if s:configuration.transparent_background == 2
   call everforest#highlight('StatusLine', s:palette.grey1, s:palette.none)
   call everforest#highlight('StatusLineTerm', s:palette.grey1, s:palette.none)
-  call everforest#highlight('StatusLineNC', s:palette.grey1, s:palette.none)
+  call everforest#highlight('StatusLineNC', s:palette.grey2, s:palette.none)
   call everforest#highlight('StatusLineTermNC', s:palette.grey1, s:palette.none)
   call everforest#highlight('TabLine', s:palette.grey2, s:palette.bg3)
   call everforest#highlight('TabLineFill', s:palette.grey1, s:palette.none)


### PR DESCRIPTION
### Description

Using the "transparent_background=2" option, the current window StatusLine gets filled with carot symbols "^^^" when working in splits. Turns out its default behavior if StatusLine == StatusLineNC [syntax.txt](https://github.com/vim/vim/blob/dd60c365cd2630794be84d63c4fe287124a30b97/runtime/doc/syntax.txt#L5497) 

I just changed the inactive StatusLineNC foreground color to a lighter grey and the carot symbols are gone.

### Screenshots

<!-- Please include any screenshots that are relevant to the pull request. -->
![everforest_laststatus2](https://user-images.githubusercontent.com/25079664/221952268-781a7eb1-79a3-4349-bf2a-36fb9a503187.png)

It looks especially annoying in combination with laststatus=3

![everforest_laststatus3](https://user-images.githubusercontent.com/25079664/221952414-5bb647ff-aef5-4311-a877-f6a4226273d2.png)
