### PR TITLE
fix(ui): change statusline colors for transparent background

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -156,10 +156,10 @@ else
   call everforest#highlight('SpellRare', s:palette.purple, s:palette.none, 'undercurl', s:palette.purple)
 endif
 if s:configuration.transparent_background == 2
-  call everforest#highlight('StatusLine', s:palette.grey1, s:palette.none)
-  call everforest#highlight('StatusLineTerm', s:palette.grey1, s:palette.none)
-  call everforest#highlight('StatusLineNC', s:palette.grey2, s:palette.none)
-  call everforest#highlight('StatusLineTermNC', s:palette.grey1, s:palette.none)
+  call everforest#highlight('StatusLine', s:palette.grey2, s:palette.none)
+  call everforest#highlight('StatusLineTerm', s:palette.grey2, s:palette.none)
+  call everforest#highlight('StatusLineNC', s:palette.grey0, s:palette.none)
+  call everforest#highlight('StatusLineTermNC', s:palette.grey0, s:palette.none)
   call everforest#highlight('TabLine', s:palette.grey2, s:palette.bg3)
   call everforest#highlight('TabLineFill', s:palette.grey1, s:palette.none)
   call everforest#highlight('TabLineSel', s:palette.bg0, s:palette.statusline1)


### PR DESCRIPTION
### Description

For a transparent background statusline,
i adjusted the colors of the current window and terminal window.
I think its more intuitive that way.

### Screenshots

before

![everforest_statusline_orig](https://user-images.githubusercontent.com/25079664/222765152-ac869167-5ba9-424b-9785-40c0efafba36.png)

after

![everforest_statusline_color](https://user-images.githubusercontent.com/25079664/222765211-2cf608ae-9d35-4e06-8b35-eb873a0bd7c9.png)

