### PR TITLE
fix(plugin): add highlight for context-start to indent-blankline

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -1148,6 +1148,7 @@ highlight! link HopUnmatched Grey
 " }}}
 " lukas-reineke/indent-blankline.nvim {{{
 call everforest#highlight('IndentBlanklineContextChar', s:palette.grey1, s:palette.none, 'nocombine')
+call everforest#highlight('IndentBlanklineContextStart', s:palette.none, s:palette.bg2)
 call everforest#highlight('IndentBlanklineChar', s:palette.bg5, s:palette.none, 'nocombine')
 highlight! link IndentBlanklineSpaceChar IndentBlanklineChar
 highlight! link IndentBlanklineSpaceCharBlankline IndentBlanklineChar


### PR DESCRIPTION
### Description

* `'nocombine'` is intentionally omitted; e.g. to preserve italics

### Screenshots

before:
![before](https://github.com/sainnhe/everforest/assets/1728352/e6109021-cde3-4421-a70c-e21bdb45ecf4)

after:
![after](https://github.com/sainnhe/everforest/assets/1728352/19eb1bd2-e603-4ca2-9f29-bed28ab6da1b)