### PR TITLE
feat(ui): add highlight definition for FloatTitle

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -139,9 +139,11 @@ call everforest#highlight('PmenuThumb', s:palette.none, s:palette.grey0)
 if s:configuration.float_style ==# 'dim'
   call everforest#highlight('NormalFloat', s:palette.fg, s:palette.bg_dim)
   call everforest#highlight('FloatBorder', s:palette.grey1, s:palette.bg_dim)
+  call everforest#highlight('FloatTitle', s:palette.fg, s:palette.bg_dim, 'bold')
 else
   call everforest#highlight('NormalFloat', s:palette.fg, s:palette.bg2)
   call everforest#highlight('FloatBorder', s:palette.grey1, s:palette.bg2)
+  call everforest#highlight('FloatTitle', s:palette.fg, s:palette.bg2, 'bold')
 endif
 call everforest#highlight('Question', s:palette.yellow, s:palette.none)
 if s:configuration.spell_foreground ==# 'none'


### PR DESCRIPTION
### Description

Adds a definition for `FloatTitle`, which is the default highlight group for neovim floating window titles. Before this change, it would link to `Title` which does not match the float background color.

### Screenshots

Before:
![Screenshot 2023-10-23 at 1 46 36 PM](https://github.com/sainnhe/everforest/assets/1728352/fdd1cc62-a95c-429f-94d7-442ccd824caf)

After:
![Screenshot 2023-10-23 at 1 43 30 PM](https://github.com/sainnhe/everforest/assets/1728352/2c2c81fa-9512-48fd-a08e-3e4b385e0189)
