### PR TITLE
Match tsx 'import' color with typescript/javascript/jsx

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -2271,6 +2271,7 @@ highlight! link tsxTSConstructor TSType
 if has('nvim-0.8.0')
   highlight! link @include.typescript typescriptTSInclude
   highlight! link @keyword.import.typescript typescriptTSInclude
+  highlight! link @keyword.import.tsx typescriptTSInclude
   highlight! link @constructor.tsx tsxTSConstructor
 endif
 if has('nvim-0.9.0')


### PR DESCRIPTION
### Description
`javascript`, `javascriptreact` and `typescript` have a purple import statement, while `typescriptreact` is red. This PR changes the `typescriptreact` import statement to purple to match the other languages.

<!--
Link any issue if valid. Example: `Fixes #(issue)`

If creating a new theme, make sure to include a README.md and update the Wiki page to reference the new theme.

If fixing a theme, please describe why the change was made.
-->

### Screenshots
Before:
<!-- Please include any screenshots that are relevant to the pull request. -->
![image](https://github.com/sainnhe/everforest/assets/31131631/64fff3d5-0559-4057-be16-fff647e1bdc2)

After:
![image](https://github.com/sainnhe/everforest/assets/31131631/3b23226c-fe99-4c39-8753-e29e16eec1b9)
