### PR TITLE
feat(highlight): add diagnostic_float_highlight

### DIFF
--- a/autoload/everforest.vim
+++ b/autoload/everforest.vim
@@ -24,6 +24,7 @@ function! everforest#get_configuration() "{{{
         \ 'lightline_disable_bold': get(g:, 'everforest_lightline_disable_bold', 0),
         \ 'diagnostic_text_highlight': get(g:, 'everforest_diagnostic_text_highlight', 0),
         \ 'diagnostic_line_highlight': get(g:, 'everforest_diagnostic_line_highlight', 0),
+        \ 'diagnostic_float_highlight': get(g:, 'everforest_diagnostic_float_highlight', 0),
         \ 'diagnostic_virtual_text': get(g:, 'everforest_diagnostic_virtual_text', 'grey'),
         \ 'disable_terminal_colors': get(g:, 'everforest_disable_terminal_colors', 0),
         \ 'better_performance': get(g:, 'everforest_better_performance', 0),

--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -354,6 +354,14 @@ else
   call everforest#highlight('InfoText', s:palette.none, s:palette.none, 'undercurl', s:palette.blue)
   call everforest#highlight('HintText', s:palette.none, s:palette.none, 'undercurl', s:palette.green)
 endif
+
+if s:configuration.diagnostic_float_highlight
+  highlight! link DiagnosticError ErrorFloat
+  highlight! link DiagnosticInfo InfoFloat
+  highlight! link DiagnosticWarn WarningFloat
+  highlight! link DiagnosticHint HintFloat
+endif
+
 if s:configuration.diagnostic_line_highlight
   call everforest#highlight('ErrorLine', s:palette.none, s:palette.bg_red)
   call everforest#highlight('WarningLine', s:palette.none, s:palette.bg_yellow)


### PR DESCRIPTION
### Description

I use `lspsaga.nvim` for a better code diagnostic experience.

Recently, I found a little issue relating to this plugin.

Diagnostic highlight in `lspsaga` uses the link option of `DaignosticError` 's highlight (which linked to `ErrorText` in `everforest`) 

But the highlight of `ErrorText` does not have the `fg` option (which is used directly by `lspsaga`) set up.

I added a user configuration named `diagnostic_float_highlight`  and used `ErrorFloat` as the link to `DiagnosticError` to fix that.


### Screenshots

Before:

![image](https://github.com/sainnhe/everforest/assets/147602513/e2571ebc-c1cf-42ad-91fb-2e4a44c8b660)

![image](https://github.com/sainnhe/everforest/assets/147602513/b2bd8506-b01b-45e1-bf08-8250639895d7)


---

After:
```lua
vim.g.everforest_diagnostic_float_highlight = 1
```
![image](https://github.com/sainnhe/everforest/assets/147602513/c1bec7de-c36a-4f5d-8b9f-c6cdb558c6fe)

![image](https://github.com/sainnhe/everforest/assets/147602513/796a32b3-5e72-4255-8a6e-a82af1915b3a)

