### PR TITLE
fix(lsp): use distinct styles for (non-)underline diags

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -10,7 +10,7 @@
 let s:configuration = everforest#get_configuration()
 let s:palette = everforest#get_palette(s:configuration.background, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = 'Sun May 19 06:34:10 PM UTC 2024'
+let s:last_modified = 'Sat Jun  1 18:40:51 UTC 2024'
 let g:everforest_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'everforest' && s:configuration.better_performance)
@@ -191,22 +191,33 @@ if has('nvim')
   call everforest#highlight('Substitute', s:palette.bg0, s:palette.yellow)
   highlight! link WinBar StatusLine
   highlight! link WinBarNC StatusLineNC
+  if s:configuration.diagnostic_text_highlight
+    call everforest#highlight('DiagnosticError', s:palette.red, s:palette.bg_red)
+    call everforest#highlight('DiagnosticUnderlineError', s:palette.none, s:palette.bg_red, 'undercurl', s:palette.red)
+    call everforest#highlight('DiagnosticWarn', s:palette.yellow, s:palette.bg_yellow)
+    call everforest#highlight('DiagnosticUnderlineWarn', s:palette.none, s:palette.bg_yellow, 'undercurl', s:palette.yellow)
+    call everforest#highlight('DiagnosticInfo', s:palette.blue, s:palette.bg_blue)
+    call everforest#highlight('DiagnosticUnderlineInfo', s:palette.none, s:palette.bg_blue, 'undercurl', s:palette.blue)
+    call everforest#highlight('DiagnosticHint', s:palette.green, s:palette.bg_green)
+    call everforest#highlight('DiagnosticUnderlineHint', s:palette.none, s:palette.bg_green, 'undercurl', s:palette.green)
+  else
+    call everforest#highlight('DiagnosticError', s:palette.red, s:palette.none)
+    call everforest#highlight('DiagnosticUnderlineError', s:palette.none, s:palette.none, 'undercurl', s:palette.red)
+    call everforest#highlight('DiagnosticWarn', s:palette.yellow, s:palette.none)
+    call everforest#highlight('DiagnosticUnderlineWarn', s:palette.none, s:palette.none, 'undercurl', s:palette.yellow)
+    call everforest#highlight('DiagnosticInfo', s:palette.blue, s:palette.none)
+    call everforest#highlight('DiagnosticUnderlineInfo', s:palette.none, s:palette.none, 'undercurl', s:palette.blue)
+    call everforest#highlight('DiagnosticHint', s:palette.green, s:palette.none)
+    call everforest#highlight('DiagnosticUnderlineHint', s:palette.none, s:palette.none, 'undercurl', s:palette.green)
+  endif
   highlight! link DiagnosticFloatingError ErrorFloat
   highlight! link DiagnosticFloatingWarn WarningFloat
   highlight! link DiagnosticFloatingInfo InfoFloat
   highlight! link DiagnosticFloatingHint HintFloat
-  highlight! link DiagnosticError ErrorText
-  highlight! link DiagnosticWarn WarningText
-  highlight! link DiagnosticInfo InfoText
-  highlight! link DiagnosticHint HintText
   highlight! link DiagnosticVirtualTextError VirtualTextError
   highlight! link DiagnosticVirtualTextWarn VirtualTextWarning
   highlight! link DiagnosticVirtualTextInfo VirtualTextInfo
   highlight! link DiagnosticVirtualTextHint VirtualTextHint
-  highlight! link DiagnosticUnderlineError ErrorText
-  highlight! link DiagnosticUnderlineWarn WarningText
-  highlight! link DiagnosticUnderlineInfo InfoText
-  highlight! link DiagnosticUnderlineHint HintText
   highlight! link DiagnosticSignError RedSign
   highlight! link DiagnosticSignWarn YellowSign
   highlight! link DiagnosticSignInfo BlueSign


### PR DESCRIPTION
Supersedes #136
Fixes https://github.com/sainnhe/gruvbox-material/issues/120
Fixes https://github.com/sainnhe/sonokai/issues/87
Fixes https://github.com/sainnhe/everforest/issues/121 (proper fix, not upstream workaround)
Fixes https://github.com/sainnhe/gruvbox-material/issues/145 (proper fix, not upstream workaround)

### Description

Ensures that `LspDiagnostic` and `LspDiagnosticUnderline` use distinct styles: highlighted for the former, underline (undercurl) for the latter.

Rationale:
- If underline is enabled in Neovim, the editor will always use the `LspDiagnosticUnderline` variant.
- By setting a foreground color for the `LspDiagnostic` variant, we ensure that the many popular plugins which leverage these highlight groups default to the correct foreground color.

I have used these settings for a bit and tried them with plugins that used to have issues with Everforest. So far I haven't noticed any problem.

### Screenshots

Nothing new to see here, but I'm including examples of highlights without/with `g:everforest_diagnostic_text_highlight` to illustrate the PR:

<img width="388" alt="Screenshot 2024-06-01 at 21 38 26" src="https://github.com/sainnhe/everforest/assets/3299086/6bb10ee8-23de-4a8b-b4a7-f0cea221482f">

<img width="388" alt="Screenshot 2024-06-01 at 21 37 47" src="https://github.com/sainnhe/everforest/assets/3299086/fdd30394-b9fb-4bfe-9354-30bed1851c3c">