### PR TITLE
Link DiagnosticUnnecessary to TSComment

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -712,7 +712,7 @@ if has('nvim-0.9')
   highlight! link @lsp.type.type TSType
   highlight! link @lsp.type.typeParameter TSTypeDefinition
   highlight! link @lsp.type.variable TSVariable
-  highlight! link DiagnosticUnnecessary WarningText
+  highlight! link DiagnosticUnnecessary TSComment
 endif
 highlight! link TSModuleInfoGood Green
 highlight! link TSModuleInfoBad Red

--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -712,7 +712,6 @@ if has('nvim-0.9')
   highlight! link @lsp.type.type TSType
   highlight! link @lsp.type.typeParameter TSTypeDefinition
   highlight! link @lsp.type.variable TSVariable
-  highlight! link DiagnosticUnnecessary TSComment
 endif
 highlight! link TSModuleInfoGood Green
 highlight! link TSModuleInfoBad Red

--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -712,6 +712,7 @@ if has('nvim-0.9')
   highlight! link @lsp.type.type TSType
   highlight! link @lsp.type.typeParameter TSTypeDefinition
   highlight! link @lsp.type.variable TSVariable
+  call everforest#highlight('DiagnosticUnnecessary', s:palette.grey1, s:palette.none)
 endif
 highlight! link TSModuleInfoGood Green
 highlight! link TSModuleInfoBad Red


### PR DESCRIPTION
### Description

As per the neovim documentation, the `DiagnosticUnnecessary` highlight group corresponds to "unnecessary or unused code." So I think it makes sense to render such code as comments (i.e., dimmed) rather then the default warning with yellow underlines. This is similar to what vscode does I believe, and creates much less visual pollution. 


<!--
Link any issue if valid. Example: `Fixes #(issue)`

If creating a new theme, make sure to include a README.md and update the Wiki page to reference the new theme.

If fixing a theme, please describe why the change was made.
-->

### Screenshots

Before:

<img width="1043" alt="Screenshot 2024-06-20 at 09 39 13" src="https://github.com/sainnhe/everforest/assets/8743306/2af45350-c460-4a2a-8895-952030b38b04">


After:
<img width="1104" alt="Screenshot 2024-06-20 at 09 40 40" src="https://github.com/sainnhe/everforest/assets/8743306/11c6543d-f8af-417f-b2d8-913c30af2fd1">


<!-- Please include any screenshots that are relevant to the pull request. -->
