### PR TITLE
Improve contrast for CurrentWord highlight

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -409,7 +409,7 @@ call everforest#highlight('HintFloat', s:palette.green, s:palette.none)
 if &diff
   call everforest#highlight('CurrentWord', s:palette.bg0, s:palette.green)
 elseif s:configuration.current_word ==# 'grey background'
-  call everforest#highlight('CurrentWord', s:palette.none, s:palette.bg2)
+  call everforest#highlight('CurrentWord', s:palette.none, s:palette.bg3)
 else
   call everforest#highlight('CurrentWord', s:palette.none, s:palette.none, s:configuration.current_word)
 endif


### PR DESCRIPTION
First of all, thank you for a really great theme which has become my default.

### Description

While really happy with the theme, I found it quite difficult to distinguish the highlighted word under cursor as implemented in plugins such as `vim-illuminate` or `vim-cursorword`. I use this feature a lot to quickly glance at all uses of the variable in the current context, but with the current colour for the highlight (`bg2`) the contrast between the highlight and the background is too low and it makes it really difficult to find all the instances. I raised the tone to `bg3` and that change alone significantly improved the usefulness of this feature without significantly impacting aesthetics.

### Screenshots

Here are a few screenshots illustrating this issue and why I believe the default should be changed. Here is the current behavior, note the little contrast between the highlighted variable and the background. In complex pieces I have to stress my eyes a lot to identify the highlight. I should also note that I have the highlight of the current line enabled NeoVIM which makes the highlight even less noticeable on the current line.

![everforest_bg2](https://github.com/user-attachments/assets/1051355a-052b-4c17-8b93-3edc44e53ab6)

Here is the same piece of code and the same highlight with Catppuccin theme where the contrast is sufficient for the highlight to be easily detectable.

![catpuccin](https://github.com/user-attachments/assets/77f5dac5-ba38-4c1e-bacf-5094ec9f14f0)

Here is the proposed change to `bg3`. Note that the highlighted word is visible much better.

![everforest_bg3](https://github.com/user-attachments/assets/2d389500-6305-4457-8502-c4c951f5d0c0)

I understand that I could manually override bg2 palette colour but that will result in undesireable changes in other components of the theme. I believe that this fairly self-contain change will improve the quality of the theme.