### PR TITLE
feat(plugin): add highlights for nvim-dap-ui controls

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -10,7 +10,7 @@
 let s:configuration = everforest#get_configuration()
 let s:palette = everforest#get_palette(s:configuration.background, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = 'Thu Oct 31 10:12:58 UTC 2024'
+let s:last_modified = 'Sun Nov 24 10:15:18 PM UTC 2024'
 let g:everforest_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'everforest' && s:configuration.better_performance)
@@ -1284,6 +1284,14 @@ highlight! link NotifyTRACETitle Purple
 " rcarriga/nvim-dap-ui {{{
 call everforest#highlight('DapUIModifiedValue', s:palette.blue, s:palette.none, 'bold')
 call everforest#highlight('DapUIBreakpointsCurrentLine', s:palette.blue, s:palette.none, 'bold')
+call everforest#highlight('DapUIPlayPause', s:palette.green, s:palette.bg2)
+call everforest#highlight('DapUIRestart', s:palette.green, s:palette.bg2)
+call everforest#highlight('DapUIStop', s:palette.red, s:palette.bg2)
+call everforest#highlight('DapUIUnavailable', s:palette.grey1, s:palette.bg2)
+call everforest#highlight('DapUIStepOver', s:palette.blue, s:palette.bg2)
+call everforest#highlight('DapUIStepInto', s:palette.blue, s:palette.bg2)
+call everforest#highlight('DapUIStepBack', s:palette.blue, s:palette.bg2)
+call everforest#highlight('DapUIStepOut', s:palette.blue, s:palette.bg2)
 highlight! link DapUIScope Blue
 highlight! link DapUIType Purple
 highlight! link DapUIDecoration Blue


### PR DESCRIPTION
### Description

adds highlights for the nvim-dap-ui control elements

### Screenshots

#### Before

inactive
![before_inactive](https://github.com/user-attachments/assets/bfb55c27-dd24-4b4f-9110-11ecfc68e8df)
inactive, window focused
![befora_focused_inactive](https://github.com/user-attachments/assets/93de5a53-d2f6-4463-afa6-d48b44a0149d)
active
![before_active](https://github.com/user-attachments/assets/f5bccd4b-4be5-488d-ac47-69f9f4b28c51)
active, window focused
![before_focused_active](https://github.com/user-attachments/assets/3225709c-bc64-4dd3-80ec-0c6186bb7668)

#### After

inactive
![after_inactive](https://github.com/user-attachments/assets/f8c044e8-440e-450e-9b23-f1105759581b)
inactive, window focused
![after_inactive_focused](https://github.com/user-attachments/assets/83648b95-b137-4a09-b1dc-766d61056659)
active
![after_active](https://github.com/user-attachments/assets/3ee04c71-bf88-48c0-97d7-997a9f60ca51)
active, window focused
![after_active_focused](https://github.com/user-attachments/assets/4bedcb19-3765-4ba6-9d9e-d0a58a970c35)



