### PR TITLE
Use Vim's `Cursor` default if no color is set

### DIFF
--- a/autoload/everforest.vim
+++ b/autoload/everforest.vim
@@ -19,7 +19,7 @@ function! everforest#get_configuration() "{{{
         \ 'dim_inactive_windows': get(g:, 'everforest_dim_inactive_windows', 0),
         \ 'disable_italic_comment': get(g:, 'everforest_disable_italic_comment', 0),
         \ 'enable_italic': get(g:, 'everforest_enable_italic', 0),
-        \ 'cursor': get(g:, 'everforest_cursor', 'auto'),
+        \ 'cursor': get(g:, 'everforest_cursor', ''),
         \ 'sign_column_background': get(g:, 'everforest_sign_column_background', 'none'),
         \ 'spell_foreground': get(g:, 'everforest_spell_foreground', 'none'),
         \ 'ui_contrast': get(g:, 'everforest_ui_contrast', 'low'),

--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -10,7 +10,7 @@
 let s:configuration = everforest#get_configuration()
 let s:palette = everforest#get_palette(s:configuration.background, s:configuration.colors_override)
 let s:path = expand('<sfile>:p') " the path of this script
-let s:last_modified = '2025年 12月 06日 星期六 05:11:59 UTC'
+let s:last_modified = 'Sat Dec 20 09:17:49 UTC 2025'
 let g:everforest_loaded_file_types = []
 
 if !(exists('g:colors_name') && g:colors_name ==# 'everforest' && s:configuration.better_performance)
@@ -88,7 +88,7 @@ else
 endif
 if s:configuration.cursor ==# 'auto'
   call everforest#highlight('Cursor', s:palette.none, s:palette.none, 'reverse')
-else
+elseif s:configuration.cursor != ''
   call everforest#highlight('Cursor', s:palette.bg0, s:palette[s:configuration.cursor])
 endif
 highlight! link vCursor Cursor

--- a/doc/everforest.txt
+++ b/doc/everforest.txt
@@ -271,15 +271,18 @@ g:everforest_cursor~
 
 Customize the cursor color.
 
+The value `'auto'` causes the color to change according to the foreground
+color of the character under the cursor.
+
 Requires setting the |guicursor| option as in the examples from the Vim doc for
 the cursor to be styled according to |hl-Cursor|.
 
 Only works in GUI clients and compatible terminal emulators.
 
     Type:               |String|
-    Available values:   `'auto'`, `'red'`, `'orange'`, `'yellow'`, `'green'`,
+    Available values:   `''`, `'auto'`, `'red'`, `'orange'`, `'yellow'`, `'green'`,
     `'aqua'`, `'blue'`, `'purple'`
-    Default value:      `'auto'`
+    Default value:      `''`
 
 ------------------------------------------------------------------------------
                                            *g:everforest_transparent_background*


### PR DESCRIPTION
### Description

Instead of defaulting to `cursor='auto'` and inherit the color of the text's foreground, use Vim's default for the `Cursor` style (`Normal` fg/bg reversed).
`cursor='auto'` remains a valid option, it is just no longer the default value.

Rationale: dynamically changing highlights can be distracting, especially for something that is constantly blinking on the screen, like in gVim or MacVim.

Since this changes a default behavior of the colorcheme, I'm assigning this to you @sainnhe for a second opinion before merging.

Closes #176

### Screenshots

Before/after on red text

<img width="1336" height="510" alt="before_1" src="https://github.com/user-attachments/assets/0439eb53-2737-448c-a164-0a7fd45be4d6" />
<img width="1336" height="510" alt="after_1" src="https://github.com/user-attachments/assets/07823089-e8b0-4a38-94d3-9afb6f6f5efd" />

Before/after on green text

<img width="1336" height="510" alt="before_2" src="https://github.com/user-attachments/assets/e50b4488-a684-4cf3-89dc-58f40538b47d" />
<img width="1336" height="510" alt="after_2" src="https://github.com/user-attachments/assets/6aaf7eba-9300-4b88-a9cf-75c6e357aed2" />