### PR TITLE
feat(agentic.nvim): add agentic.nvim highlights

### DIFF
--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -1592,6 +1592,21 @@ highlight! link NeotestFailed RedSign
 highlight! link NeotestRunning YellowSign
 highlight! link NeotestSkipped BlueSign
 " }}}
+" carlos-algms/agentic.nvim {{{
+call everforest#highlight('AgenticDiffAddWord', s:palette.bg0, s:palette.bg_green, 'bold')
+call everforest#highlight('AgenticDiffDeleteWord', s:palette.bg0, s:palette.bg_red, 'bold')
+call everforest#highlight('AgenticSpinnerGenerating', s:palette.blue, s:palette.none, 'bold')
+call everforest#highlight('AgenticSpinnerSearching', s:palette.yellow, s:palette.none, 'bold')
+call everforest#highlight('AgenticSpinnerThinking', s:palette.purple, s:palette.none, 'bold')
+call everforest#highlight('AgenticStatusCompleted', s:palette.bg0, s:palette.green)
+call everforest#highlight('AgenticStatusFailed', s:palette.bg0, s:palette.red)
+call everforest#highlight('AgenticStatusPending', s:palette.bg0, s:palette.purple)
+call everforest#highlight('AgenticThinking', s:palette.bg0, s:palette.bg3)
+call everforest#highlight('AgenticTitle', s:palette.bg0, s:palette.blue, 'bold')
+highlight! link AgenticCodeBlockFence Directory
+highlight! link AgenticDiffAdd DiffAdd
+highlight! link AgenticSpinnerBusy Comment
+" }}}
 endif
 " }}}
 " Extended File Types: {{{

--- a/colors/everforest.vim
+++ b/colors/everforest.vim
@@ -1603,9 +1603,6 @@ call everforest#highlight('AgenticStatusFailed', s:palette.bg0, s:palette.red)
 call everforest#highlight('AgenticStatusPending', s:palette.bg0, s:palette.purple)
 call everforest#highlight('AgenticThinking', s:palette.bg0, s:palette.bg3)
 call everforest#highlight('AgenticTitle', s:palette.bg0, s:palette.blue, 'bold')
-highlight! link AgenticCodeBlockFence Directory
-highlight! link AgenticDiffAdd DiffAdd
-highlight! link AgenticSpinnerBusy Comment
 " }}}
 endif
 " }}}


### PR DESCRIPTION
see: https://github.com/carlos-algms/agentic.nvim/pull/153

### Description
Adds support for [agentic.nvim](https://github.com/carlos-algms/agentic.nvim) highlights

<img width="1919" height="1023" alt="image" src="https://github.com/user-attachments/assets/f4acea8c-05da-411e-b955-1e47d5e4d306" />
<img width="769" height="745" alt="image" src="https://github.com/user-attachments/assets/6825b02d-af97-4347-bb4f-82b3a04257df" />
